### PR TITLE
Remove merge_group trigger from Run Tests workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,13 +1,10 @@
 name: Run Tests
-run-name: Running tests for ${{ github.event_name }} on ${{ github.ref_name }}
+run-name: Running tests for ${{ github.event_name }} on \#${{ github.ref_name }}
 
 on:
   pull_request:
-    # branches:
-    #   - main
-  # merge_group:
-  #   types:
-  #     - checks_requested
+    branches:
+      - main
 
 jobs:
   test_dotnet:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,8 +3,8 @@ run-name: Running tests for ${{ github.event_name }} on ${{ github.ref_name }}
 
 on:
   pull_request:
-    branches:
-      - main
+    # branches:
+    #   - main
   # merge_group:
   #   types:
   #     - checks_requested

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,9 +5,9 @@ on:
   pull_request:
     branches:
       - main
-  merge_group:
-    types:
-      - checks_requested
+  # merge_group:
+  #   types:
+  #     - checks_requested
 
 jobs:
   test_dotnet:


### PR DESCRIPTION
This removes the `merge_group` trigger for the *Run Tests* workflow (`.github/workflows/build-and-test.yml`).

It was originally included because I was considering adding a demo of how to set up a ruleset to require status checks before a PR can be merged to `main` (the `merge_group` trigger must be present if you're using a workflow as a required status check), but have since decided that it's out-of-scope for this lecture.

